### PR TITLE
Allow On-Hold order status as the subscribe event

### DIFF
--- a/components/integration/integration.php
+++ b/components/integration/integration.php
@@ -116,6 +116,7 @@ class CKWC_Integration extends WC_Integration {
 				'desc_tip'    => false,
 				'options'     => array(
 					'pending'    => __( 'Order Created' ),
+					'on-hold'    => __( 'Order On-Hold' ),
 					'processing' => __( 'Order Processing' ),
 					'completed'  => __( 'Order Completed' ),
 				),


### PR DESCRIPTION
This changes the extension's settings to allow On-Hold to be chosen as the subscribe event. If this option is selected, then customers with orders which move to the On-Hold status will be sent to ConvertKit as subscribers.

Closes #57